### PR TITLE
Feature/better resource command

### DIFF
--- a/install-stubs/base-resource.php
+++ b/install-stubs/base-resource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Front;
+namespace App\Front\Resources;
 
 use WeblaborMx\Front\Resource as Base;
 

--- a/src/Console/Commands/CreateResource.php
+++ b/src/Console/Commands/CreateResource.php
@@ -4,7 +4,6 @@ namespace WeblaborMx\Front\Console\Commands;
 
 use Illuminate\Console\Command;
 use WeblaborMX\FileModifier\FileModifier;
-use Illuminate\Support\Str;
 
 class CreateResource extends Command
 {
@@ -13,7 +12,11 @@ class CreateResource extends Command
      *
      * @var string
      */
-    protected $signature = 'front:resource {dir_location} {--all}';
+    protected $signature = 'front:resource
+                            {model : The class name of the model from which to create the resource}
+                            {--a|all : Generate a resource with the model, policy, migration}
+                            {--m|model : Create a new model and migration for the resource}
+                            {--p|policy : Create a new policy for the model of the resource}';
 
     /**
      * The console command description.
@@ -29,73 +32,127 @@ class CreateResource extends Command
      */
     public function handle()
     {
-        $directory = WLFRONT_PATH.'/install-stubs';
-        $dir_location = $this->argument('dir_location');
-        $model = str_replace('/', '\\', $dir_location);
-        $model_name = class_basename($model);
-        $model_extra_path = str_replace($model_name, '', $model);
-        if(strlen($model_extra_path)>0) {
-            $model_extra_path = '\\'.trim($model_extra_path, '\\');
-        }
-        $slug = Str::plural(Str::snake($model_name));
-        $url = strtolower(str_replace($model_name, $slug, $dir_location));
+        $this->createFrontDir();
+        $this->createResourceParent();
 
-        // Create Front Folder if doesnt exist
-        $dir = str_replace('\\', '/', base_path(str_replace('App', 'app', config('front.resources_folder'))));
-        if (!is_dir(app_path('Front'))) {
-            mkdir(app_path('Front'));
-            $this->line('Front folder created: <info>✔</info>');
-        }
+        $model = str($this->argument('model'))->replace('/', '\\');
 
-        // Create resources front folder
-        if(app_path('Front')!=$dir && !is_dir($dir)) {
-            mkdir($dir);
-            $this->line('Front resources folder created: <info>✔</info>');
-        }
+        $class = $model
+            ->prepend(config('front.models_folder') . '\\')
+            ->replace('App\\Models', '')
+            ->replace('App', '')
+            ->trim('/')
+            ->trim('\\');
 
-        // Create resource base
-        $file_name = $dir.'/Resource.php';
-        if(!FileModifier::file($file_name)->exists()) {
-            copy($directory.'/base-resource.php', $file_name);
-            $this->line('Resource base class created: <info>✔</info>');
+        $classBasename = $class->classBasename();
+        $classVendor = $class->beforeLast("{$classBasename}")->trim('\\');
+
+        $filename = $classVendor
+            ->replace('\\', '/')
+            ->append("/{$classBasename}")
+            ->append('.php')
+            ->toString();
+        $filename = $this->resolveFrontDir($filename);
+
+        $slug = $classBasename->snake()->plural();
+
+        if (is_file($filename)) {
+            $this->error($class . ' already exists.');
+            return;
         }
 
-        // Create resource
-        $file_name = $dir.'/'.$dir_location.'.php';
-        if(!FileModifier::file($file_name)->exists()) {
-            copy($directory.'/resource.php', $file_name);
-
-            FileModifier::file($file_name)
-                ->replace('{model}', $model)
-                ->replace('{model_name}', $model_name)
-                ->replace('{model_folder}', config('front.models_folder'))
-                ->replace('{default_base_url}', config('front.default_base_url'))
-                ->replace('{url}', $url)
-                ->replace('{model_extra_path}', $model_extra_path)
-                ->replace('{resources_folder}', config('front.resources_folder'))
-                ->execute();
-
-            $this->line('Resource created: <info>✔</info>');
+        if ($this->option('all')) {
+            $this->input->setOption('policy', true);
+            $this->input->setOption('model', true);
         }
 
-        $all = $this->option('all');
-        if($all) {
-            $var = config('front.models_folder').'\\'.$model;
-            $var = str_replace('App\Models', '', $var);
-            $var = str_replace('App', '', $var);
-            $var = trim($var, '/');
-            $var = trim($var, '\\');
-            $var = str_replace('\\', '/', $var);
-            
-            try {
-                \Artisan::call("make:model {$var} -m");
-                $this->line('Model created: <info>✔</info>');
-                $this->line('Migration created: <info>✔</info>');
-            } catch (\Exception $e) {
-                
-            }
-            \Artisan::call("make:policy {$model_name}Policy --model={$var}");
-            $this->line('Policy created: <info>✔</info>');
+        if ($this->option('model')) {
+            $this->call('make:model', ['name' => $class]);
+            $this->call('make:migration', ['name' => "create_{$slug}_table"]);
+        }
+
+        if ($this->option('policy')) {
+            $this->call('make:policy', [
+                'name' => "{$classBasename}Policy",
+                '--model' => $class
+            ]);
+        }
+
+        $parent = config('front.resources_folder') . '\\Resource';
+
+        $namespace = config('front.models_folder') . "\\" . collect([
+            $classVendor->toString(),
+            $classBasename->toString()
+        ])->filter()->implode('\\');
+
+        $url = $classVendor->lower()->replace('\\', '/')->append("/$slug");
+
+        if (!is_dir($dirname = dirname($filename))) {
+            mkdir($dirname, 0755, true);
+        }
+
+        copy($this->resolveStubPath('/resource.stub'), $filename);
+
+        FileModifier::file($filename)
+            ->replace('{{ model }}', "App\\Models\\$class")
+            ->replace('{{ class }}', $classBasename)
+            ->replace('{{ parent }}', $parent)
+            ->replace('{{ default_base_url }}', config('front.default_base_url'))
+            ->replace('{{ url }}', $url)
+            ->replace('{{ namespace }}', $namespace)
+            ->execute();
+
+        $this->components->info(sprintf('Resource [%s] created successfully.', $this->prettifyPath($filename)));
+    }
+
+    protected function prettifyPath($path)
+    {
+        return str($path)->after(base_path())->trim('/');
+    }
+
+    protected function resolveFrontDir($path = '')
+    {
+        $vendor = str(config('front.resources_folder'));
+        return str(base_path(
+            $vendor
+                ->after('\\')
+                ->prepend(
+                    $vendor->before('\\')
+                        ->snake()
+                        ->append('\\')
+                )
+                ->replace('\\', '/')
+        ))->append('/' . ltrim($path, '/'))
+            ->rtrim('/')
+            ->toString();
+    }
+
+    protected function resolveStubPath($stub)
+    {
+        $stub = trim($stub, '/');
+        return file_exists($customPath = $this->laravel->basePath('/stubs/' . $stub))
+            ? $customPath
+            : __DIR__ . '/stubs/' . $stub;
+    }
+
+    protected function createFrontDir()
+    {
+        $path = $this->resolveFrontDir();
+
+        if (!is_dir($path)) {
+            mkdir($path, 0755, true);
+            $this->components->info(sprintf('Folder [%s] created successfully.', $this->prettifyPath($path)));
+        }
+    }
+
+    protected function createResourceParent()
+    {
+        $path = $this->resolveFrontDir('/Resource.php');
+        $directory = WLFRONT_PATH . '/install-stubs';
+
+        if (!FileModifier::file($path)->exists()) {
+            copy($directory . '/base-resource.php', $path);
+            $this->components->info(sprintf('Class [%s] created successfully.', $this->prettifyPath($path)));
         }
     }
 }

--- a/src/Console/Commands/stubs/resource.stub
+++ b/src/Console/Commands/stubs/resource.stub
@@ -1,15 +1,15 @@
 <?php
 
-namespace {resources_folder}{model_extra_path};
+namespace {{ namespace }};
 
 use WeblaborMx\Front\Inputs\ID;
 use WeblaborMx\Front\Inputs\Text;
-use {model_folder}\{model} as Model;
-use {resources_folder}\Resource;
+use {{ model }} as Model;
+use {{ parent }};
 
-class {model_name} extends Resource
+class {{ class }} extends Resource
 {
-    public $base_url = '{default_base_url}/{url}';
+    public $base_url = '{{ default_base_url }}/{{ url }}';
     public $model = Model::class;
     public $title = 'id';
 


### PR DESCRIPTION
The pull request improves the `front:resource` command with the following changes:

- [X] Added options to create model or policy separately with `--model` and `--policy`.
- [X] Standarized the resource stub with Laravel syntax.
- [X] You can now replace the resource stub like any other Laravel stubs (`/stub/resource.stub`).