### PR TITLE
remove redirect from destroy in FrontController

### DIFF
--- a/src/Http/Controllers/FrontController.php
+++ b/src/Http/Controllers/FrontController.php
@@ -154,13 +154,7 @@ class FrontController extends Controller
 
         // Front code
         $front = $this->front->setSource('show')->setObject($object);
-        $response = $this->run(new FrontDestroy($front, $object));
-        if($this->isResponse($response)) {
-            return $response;
-        }
-
-        // Redirect
-        return redirect($this->front->getBaseUrl());
+        return $this->run(new FrontDestroy($front, $object));
     }
 
     /*


### PR DESCRIPTION
"destroy" is only called with ajax, having a redirect causes the page to reload twice and "flash messages" do not work either