### PR TITLE
Correcion de commit f7f3cce85e0e435737d0d6245b21bc56e9f05015

### DIFF
--- a/src/Jobs/FrontDestroy.php
+++ b/src/Jobs/FrontDestroy.php
@@ -26,7 +26,7 @@ class FrontDestroy
     public function handle()
     {
         // Call the action to be done before is deleted
-        if (!$this->front->destroy($this->object)) {
+        if ($this->front->destroy($this->object) === false) {
             return false;
         }
 


### PR DESCRIPTION
En el anterior commit (https://github.com/weblabormx/laravel-front/commit/f7f3cce85e0e435737d0d6245b21bc56e9f05015) se introdujo un error que no considero el caso en el que un "resource" no implememnta el metodo "destroy", este PR lo corrige
- si el resource no implementa el metodo "destroy" el valor de retorno es null, y no deja continuar con el proceso de eliminacion en "FrontDestroy"